### PR TITLE
job:  #12291 update parser to use platform independent methods for se…

### DIFF
--- a/model/aslloader/src/main/java/org/xtuml/aslloader/parser/AslImportParser.java
+++ b/model/aslloader/src/main/java/org/xtuml/aslloader/parser/AslImportParser.java
@@ -38,7 +38,7 @@ public class AslImportParser implements IGenericLoader {
     System.out.println("Parsing resource: " + fileURI);
 
     try (InputStream is = fileURI.toURL().openConnection().getInputStream()) {
-      final String filename = Path.of(fileURI.toURL().getPath()).getFileName().toString();
+      final String filename = new File(fileURI.getPath()).getName();
 
       // Tokenize the file
       CharStream input = CharStreams.fromStream(is);


### PR DESCRIPTION
…tting filename

Not sure why `Path.of()` doesn't like colons in the name but 🤷🏻‍♂️ Here's a version that works on both Windows and macOS and does the same thing.